### PR TITLE
Remove deprecation warnings during build in ros2 

### DIFF
--- a/turtlebot3_dqn/setup.cfg
+++ b/turtlebot3_dqn/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/turtlebot3_dqn
+script_dir=$base/lib/turtlebot3_dqn
 [install]
-install-scripts=$base/lib/turtlebot3_dqn
+install_scripts=$base/lib/turtlebot3_dqn


### PR DESCRIPTION
Changed dashed-separated script usage of 'script-dir' 'install-scripts' to underscore: 'script-dir' 'install_scripts' in setup.cfg
