### PR TITLE
Suppress verbose output

### DIFF
--- a/turtlebot3_dqn/turtlebot3_dqn/dqn_agent.py
+++ b/turtlebot3_dqn/turtlebot3_dqn/dqn_agent.py
@@ -151,7 +151,7 @@ class DQNAgent(Node):
             while True:
                 local_step += 1
 
-                q_values = self.model.predict(state)
+                q_values = self.model.predict(state, verbose=0)
                 sum_max_q += float(numpy.max(q_values))
 
                 action = int(self.get_action(state))
@@ -246,9 +246,9 @@ class DQNAgent(Node):
             if lucky > (1 - self.epsilon):
                 result = random.randint(0, self.action_size - 1)
             else:
-                result = numpy.argmax(self.model.predict(state))
+                result = numpy.argmax(self.model.predict(state, verbose=0))
         else:
-            result = numpy.argmax(self.model.predict(state))
+            result = numpy.argmax(self.model.predict(state, verbose=0))
 
         return result
 
@@ -300,11 +300,11 @@ class DQNAgent(Node):
 
         current_states = numpy.array([transition[0] for transition in data_in_mini_batch])
         current_states = current_states.squeeze()
-        current_qvalues_list = self.model.predict(current_states)
+        current_qvalues_list = self.model.predict(current_states, verbose=0)
 
         next_states = numpy.array([transition[3] for transition in data_in_mini_batch])
         next_states = next_states.squeeze()
-        next_qvalues_list = self.target_model.predict(next_states)
+        next_qvalues_list = self.target_model.predict(next_states, verbose=0)
 
         x_train = []
         y_train = []

--- a/turtlebot3_dqn/turtlebot3_dqn/dqn_test.py
+++ b/turtlebot3_dqn/turtlebot3_dqn/dqn_test.py
@@ -108,7 +108,6 @@ class DQNTest(Node):
                     action = int(self.get_action(state))
 
                 req = Dqn.Request()
-                print(int(action))
                 req.action = action
                 req.init = init
 
@@ -161,8 +160,7 @@ class DQNTest(Node):
             return random.randrange(self.action_size)
         else:
             state = numpy.asarray(state)
-            q_value = self.model.predict(state.reshape(1, len(state)))
-            print(numpy.argmax(q_value[0]))
+            q_value = self.model.predict(state.reshape(1, len(state)), verbose=0)
             return numpy.argmax(q_value[0])
 
     def train_model(self, target_train_start=False):
@@ -177,13 +175,13 @@ class DQNTest(Node):
             next_state = numpy.asarray(mini_batch[i][3])
             done = numpy.asarray(mini_batch[i][4])
 
-            q_value = self.model.predict(state.reshape(1, len(state)))
+            q_value = self.model.predict(state.reshape(1, len(state)), verbose=0)
             self.max_q_value = numpy.max(q_value)
 
             if not target_train_start:
-                target_value = self.model.predict(next_state.reshape(1, len(next_state)))
+                target_value = self.model.predict(next_state.reshape(1, len(next_state)), verbose=0)
             else:
-                target_value = self.target_model.predict(next_state.reshape(1, len(next_state)))
+                target_value = self.target_model.predict(next_state.reshape(1, len(next_state)), verbose=0)
 
             if done:
                 next_q_value = reward

--- a/turtlebot3_dqn/turtlebot3_dqn/dqn_test.py
+++ b/turtlebot3_dqn/turtlebot3_dqn/dqn_test.py
@@ -135,7 +135,13 @@ class DQNTest(Node):
                                 'Exception while calling service: {0}'.format(future.exception()))
 
                         break
-
+            if done:
+                print(
+                    'Episode:', episode,
+                    'score:', score,
+                    'memory length:', len(self.memory),
+                    'epsilon:', self.epsilon)
+                
                 time.sleep(0.01)
 
     def build_model(self):


### PR DESCRIPTION
Suppresses excessive terminal output by setting verbose=0 in model.predict() calls during training and testing. It also removes print() statements likely intended for debugging and adds a consistent print() statement message in the test phase to align with the training phase.