### PR TITLE
Add ament_cmake buildtool_depend tag in metapackage

### DIFF
--- a/turtlebot3_dqn/CHANGELOG.rst
+++ b/turtlebot3_dqn/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package turtlebot3_dqn
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.3 (2026-01-19)
+------------------
+* None
+
 1.0.2 (2026-01-06)
 ------------------
 * Fixed a bug in the JSON file where the step parameter was incorrectly named; renamed it to step_counter.

--- a/turtlebot3_dqn/package.xml
+++ b/turtlebot3_dqn/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>turtlebot3_dqn</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
     The turtlebot3_dqn package using reinforcement learning with DQN (Deep Q-Learning).
   </description>

--- a/turtlebot3_dqn/setup.py
+++ b/turtlebot3_dqn/setup.py
@@ -15,7 +15,7 @@ author_emails = ', '.join(email for _, email in authors_info)
 
 setup(
     name=package_name,
-    version='1.0.2',
+    version='1.0.3',
     packages=find_packages(),
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),

--- a/turtlebot3_machine_learning/CHANGELOG.rst
+++ b/turtlebot3_machine_learning/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package turtlebot3_machine_learning
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.0.3 (2026-01-19)
+------------------
+* Added ament_cmake as a buildtool_depend
+* Contributors: Hyungyu Kim
+
 1.0.2 (2026-01-06)
 ------------------
 * Fixed a bug in the JSON file where the step parameter was incorrectly named; renamed it to step_counter.

--- a/turtlebot3_machine_learning/package.xml
+++ b/turtlebot3_machine_learning/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>turtlebot3_machine_learning</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
     This metapackage for ROS 2 TurtleBot3 machine learning.
   </description>
@@ -13,6 +13,7 @@
   <author email="kkjong@robotis.com">Gilbert</author>
   <author email="dddoggi1207@gmail.com">ChanHyeong Lee</author>
   <author email="kimhg@robotis.com">Hyungyu Kim</author>
+  <buildtool_depend>ament_cmake</buildtool_depend>
   <exec_depend>turtlebot3_dqn</exec_depend>
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
- Add ament_cmake buildtool_depend tag in metapackage for fixing bloom CI build error.